### PR TITLE
Rename 'create_entity' to 'register'

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -59,7 +59,23 @@ impl StacksClient {
             .await
     }
 
-    pub async fn create_entity(
+    pub async fn query(
+        &self,
+        entity: &str,
+        database: &str,
+        query: &str,
+    ) -> Result<QueryResult, StacksError> {
+        let response = reqwest::Client::new()
+            .post(self.make_url(format!("{}/{}/query", entity, database)))
+            .body(query.to_owned())
+            .send()
+            .await?;
+
+        self.handle_response(response, reqwest::StatusCode::OK)
+            .await
+    }
+
+    pub async fn register(
         &self,
         entity: &str,
         entity_type: &EntityType,
@@ -77,22 +93,6 @@ impl StacksClient {
             .await?;
 
         self.handle_response(response, reqwest::StatusCode::CREATED)
-            .await
-    }
-
-    pub async fn query(
-        &self,
-        entity: &str,
-        database: &str,
-        query: &str,
-    ) -> Result<QueryResult, StacksError> {
-        let response = reqwest::Client::new()
-            .post(self.make_url(format!("{}/{}/query", entity, database)))
-            .body(query.to_owned())
-            .send()
-            .await?;
-
-        self.handle_response(response, reqwest::StatusCode::OK)
             .await
     }
 }

--- a/src/http/endpoints.rs
+++ b/src/http/endpoints.rs
@@ -31,21 +31,6 @@ async fn create_database(
     Ok(HttpResponse::Created().json(APIDatabase::from_persisted(&entity, &created_database)))
 }
 
-#[post("/v1/{entity}")]
-async fn create_entity(
-    path: web::Path<EntityPath>,
-    req: HttpRequest,
-    db_pool: web::Data<sqlx::PgPool>,
-) -> Result<HttpResponse, StacksError> {
-    let entity_type = get_header(req, "entity-type")?;
-    let entity = Entity {
-        slug: path.entity.clone(),
-        entity_type: EntityType::from_str(&entity_type) as i16,
-    };
-    let created_entity = create_entity_crud(&entity, &db_pool).await?;
-    Ok(HttpResponse::Created().json(APIEntity::from_persisted(&created_entity)))
-}
-
 #[post("/v1/{entity}/{database}/query")]
 async fn query(
     path: web::Path<EntityDatabasePath>,
@@ -59,4 +44,19 @@ async fn query(
     let db_path = database_path(entity_slug, database_slug)?;
     let result = run_query(&db_path, &query, &db_type)?;
     Ok(web::Json(result))
+}
+
+#[post("/v1/{entity}")]
+async fn register(
+    path: web::Path<EntityPath>,
+    req: HttpRequest,
+    db_pool: web::Data<sqlx::PgPool>,
+) -> Result<HttpResponse, StacksError> {
+    let entity_type = get_header(req, "entity-type")?;
+    let entity = Entity {
+        slug: path.entity.clone(),
+        entity_type: EntityType::from_str(&entity_type) as i16,
+    };
+    let created_entity = create_entity_crud(&entity, &db_pool).await?;
+    Ok(HttpResponse::Created().json(APIEntity::from_persisted(&created_entity)))
 }

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -1,4 +1,4 @@
-use crate::http::endpoints::{create_database, create_entity, query};
+use crate::http::endpoints::{create_database, query, register};
 use actix_web::{middleware, web, App, HttpServer};
 use serde::{Deserialize, Serialize};
 use sqlx::migrate;
@@ -16,8 +16,8 @@ struct Config {
 
 pub fn config(cfg: &mut web::ServiceConfig) {
     cfg.service(create_database);
-    cfg.service(create_entity);
     cfg.service(query);
+    cfg.service(register);
 }
 
 pub async fn run_server(config_path: &PathBuf) -> std::io::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,17 +77,6 @@ async fn main() -> std::io::Result<()> {
                         ),
                 )
                 .subcommand(
-                    Command::new("create_entity")
-                        .about("Create an entity")
-                        .arg(arg!(<entity> "The entity to create")
-                             .required(true))
-                        .arg(
-                            arg!(<type> "The type of entity")
-                                .value_parser(value_parser!(EntityType))
-                                .default_value(EntityType::User.to_str())
-                                .required(false)),
-                )
-                .subcommand(
                     Command::new("query")
                         .about("Query a database")
                         .arg(arg!(<database> "The database to which to connect (e.g., entity/database.sqlite")
@@ -101,7 +90,18 @@ async fn main() -> std::io::Result<()> {
                                 .value_parser(value_parser!(OutputFormat))
                                 .default_value(OutputFormat::Table.to_str())
                                 .required(false)),
-                ),
+                )
+                .subcommand(
+                    Command::new("register")
+                        .about("Register a user/organization")
+                        .arg(arg!(<entity> "The entity to create")
+                             .required(true))
+                        .arg(
+                            arg!(<type> "The type of entity")
+                                .value_parser(value_parser!(EntityType))
+                                .default_value(EntityType::User.to_str())
+                                .required(false)),
+                )
         )
         .get_matches();
 
@@ -154,12 +154,12 @@ async fn main() -> std::io::Result<()> {
                         }
                     }
                 }
-            } else if let Some(matches) = matches.subcommand_matches("create_entity") {
+            } else if let Some(matches) = matches.subcommand_matches("register") {
                 if let (Some(entity), Some(entity_type)) = (
                     matches.get_one::<String>("entity"),
                     matches.get_one::<EntityType>("type"),
                 ) {
-                    match client.create_entity(entity, entity_type).await {
+                    match client.register(entity, entity_type).await {
                         Ok(_response) => {
                             println!("Successfully registered {}", entity);
                         }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -32,17 +32,17 @@ fn client_server_integration() -> Result<(), Box<dyn std::error::Error>> {
         .spawn()?;
     thread::sleep(time::Duration::from_secs(1));
 
-    // Create entity.
+    // Register an entity.
     Command::cargo_bin("stacks")?
-        .args(["client", "create_entity", "e2e"])
+        .args(["client", "register", "e2e"])
         .env("STACKS_SERVER_URL", "http://127.0.0.1:5433")
         .assert()
         .success()
         .stdout("Successfully registered e2e\n");
 
-    // Can't create an entity twice.
+    // Can't register an entity twice.
     Command::cargo_bin("stacks")?
-        .args(["client", "create_entity", "e2e"])
+        .args(["client", "register", "e2e"])
         .env("STACKS_SERVER_URL", "http://127.0.0.1:5433")
         .assert()
         .success()


### PR DESCRIPTION
Ahead of #13, renaming this endpoint for clarity.